### PR TITLE
Be more explicit about the `withTheme` return type

### DIFF
--- a/src/ThemeContext.tsx
+++ b/src/ThemeContext.tsx
@@ -28,11 +28,11 @@ export interface ThemeContext<Theme> {
   watchTheme: (callback: WatchCallback<Theme>) => Unsubscribe
 
   // React component access:
-  ThemeProvider: React.ComponentType<ThemeProviderProps>
+  ThemeProvider: (props: ThemeProviderProps) => JSX.Element
   useTheme: () => Theme
   withTheme: <Props extends { theme: Theme }>(
     Component: React.ComponentType<Props>
-  ) => React.ComponentType<RemoveTheme<Props>>
+  ) => (props: RemoveTheme<Props>) => JSX.Element
 }
 
 /**
@@ -77,7 +77,7 @@ export function makeThemeContext<Theme>(
 
   function withTheme<Props extends { theme: Theme }>(
     Component: React.ComponentType<Props>
-  ): React.ComponentType<RemoveTheme<Props>> {
+  ): (props: RemoveTheme<Props>) => JSX.Element {
     function WithTheme(props: RemoveTheme<Props>): JSX.Element {
       const theme = React.useContext(Context)
       // @ts-expect-error

--- a/src/index.flow.js
+++ b/src/index.flow.js
@@ -35,7 +35,7 @@ export type ThemeContext<Theme> = {
   useTheme(): Theme,
   withTheme<Props: { theme: Theme }>(
     Component: React.ComponentType<Props>
-  ): React.ComponentType<RemoveTheme<Theme, Props>>
+  ): (props: RemoveTheme<Theme, Props>) => React.Node
 }
 
 declare export function makeThemeContext<Theme>(


### PR DESCRIPTION
### Fixed

- Be more explicit about component return types, to help Flow & Typescript return more accurate errors.